### PR TITLE
added multi-symboled prefix and suffix

### DIFF
--- a/components/builder/parsing.component.js
+++ b/components/builder/parsing.component.js
@@ -1,5 +1,3 @@
-/*jshint esversion:6*/
-
 /**
  * Replaces text with the values in the lookup parameter.
  *
@@ -18,8 +16,12 @@ exports.parse = (text, lookup, options) => {
         suffix: ')'
     };
 
+    o.prefix = escape(o.prefix);
+    o.suffix = escape(o.suffix);
+
     // regular expression to replace string surrounded by prefix and suffix
-    const regex = new RegExp("[" + o.prefix + "]([^" + o.suffix + "]*)[" + o.suffix + "]", "gim");
+    const regex = new RegExp(o.prefix + "([^" + o.suffix + "]*)" + o.suffix, "gim");
+    
     return text.replace(regex, (delimitedTerm, term) => {
         var params = null;
         if (term.indexOf(',') !== -1) {
@@ -36,3 +38,22 @@ exports.parse = (text, lookup, options) => {
         } else return delimitedTerm;
     });
 };
+
+/**
+ *  Escapes special characters for Regular Expressions
+ * 
+ * @param {*} text 
+ */
+function escape(text){
+    var invalid = ['*', '^', '\\', '$', '+', '?', '.', '(', ')', '[', ']', '{', '}', '|'];
+    var chars = [];
+    for(var i = 0; i < text.length; i++){
+        var c = text.charAt(i);
+        if(invalid.includes(c)){
+            chars.push(`\\${c}`);
+        } else {
+            chars.push(c);
+        }
+    }
+    return chars.join('');
+}

--- a/components/builder/sequence.component.js
+++ b/components/builder/sequence.component.js
@@ -1,5 +1,3 @@
-/*jshint esversion:6*/
-
 /**
  * Given a sequence, it replaces all values inside the sequence with
  * the user defined template and then returns a string which contains

--- a/components/builder/template.component.js
+++ b/components/builder/template.component.js
@@ -1,4 +1,3 @@
-/*jshint esversion:6*/
 
 class Template {
     constructor() {

--- a/services/text.service.js
+++ b/services/text.service.js
@@ -1,4 +1,3 @@
-/*jshint esversion:6*/
 
 exports.transpose = (str, table, backwards) => {
     var last,

--- a/tests/builder.modules.tests.js
+++ b/tests/builder.modules.tests.js
@@ -20,6 +20,34 @@ describe('build invalid input tests', () => {
 });
 
 describe('builder options tests', () => {
+    it('should allow multiple prefixes and suffixes', () => {
+        const options = {
+            prefix: '--',
+            suffix: '--'
+        };
+        const input = '--bear--';
+        const expected = 'ʕ·͡ᴥ·ʔ﻿';
+        const output = builderModule.parse(input, options);
+        expect(output).to.equal(expected);
+    });
+
+    it('should allow multiple prefixes and suffixes using Regex special characters', () => {
+        const special = ['*', '^', '\\', '$', '+', '?', '.', '(', ')', '[', ']', '{', '}', '|'];
+        const doTest = (symbol) => {
+            const options = {
+                prefix: `${symbol}${symbol}`,
+                suffix: `${symbol}${symbol}`
+            };
+            const input = `${symbol}${symbol}bear${symbol}${symbol}`;
+            const expected = 'ʕ·͡ᴥ·ʔ﻿';
+            const output = builderModule.parse(input, options);
+            expect(output).to.equal(expected);
+        };
+        for(var item of special){
+            doTest(item);
+        }
+    });
+
     it('should allow custom options', () => {
         const options = {
             prefix: ':',


### PR DESCRIPTION
# Asciimoticon Pull Request Information

## Brief Description
Added multi-symboled prefix and suffix options

## Related Issues
- #35 Options Prefix can only support one delimiter

## Additional Features
Not applicable since this is a patch

## Fixes

Please list any fixes you have made in the existing modules (if applicable)

- Multi-symboled options
-
-

## Testing

Please list the tests you have created.

- test in `builder.modules.tests.js` to see if multi-symboled options addition works
- test in `builder.modules.tests.js`  that runs it against Regex special characters
-

@chrisrabe
